### PR TITLE
Make regular expression multiline

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -29,7 +29,7 @@ class ReplaceRule {
 	replacer: string;
 
 	constructor(pattern: string, replacer: string) {
-		this.pattern = new RegExp(pattern, 'g');
+		this.pattern = new RegExp(pattern, 'gm');
 		this.replacer = replacer;
 	}
 }


### PR DESCRIPTION
This allows `^` and `$` to match next to newline characters.

In multiline mode start and end of the string still can be matched with `\A` and `\Z` permanent anchors.