### PR TITLE
add paste transform toggle, rule names, and selected-text replacers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,10 @@
+# Agent Task Index
+
+This file routes AI agents to the correct instruction file depending on the task.
+
+| Task | Instruction file |
+|------|-----------------|
+| Understand project architecture | [agents/architecture.md](agents/architecture.md) |
+| Run or write tests | [agents/testing.md](agents/testing.md) |
+| Update documentation (README, architecture) | [agents/update-documentation.md](agents/update-documentation.md) |
+| Create a Pull Request | [agents/create-pr.md](agents/create-pr.md) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@./AGENTS.md

--- a/README.md
+++ b/README.md
@@ -24,7 +24,24 @@ Use regex replacer for simple tasks.
 You can read more about regexp at [javascript documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions).
 You can read more about replacement string at [javascript documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#specifying_a_string_as_the_replacement).
 
-The plugin contains some default rules for GitHub and Wikipedia as example. 
+The plugin contains some default rules for GitHub and Wikipedia as example.
+
+Rules are applied sequentially: the output of one rule is passed as input to the next.
+
+### Replacer (with selection)
+
+Each regex rule has an optional second replacer field: "Replacer (with selection)". When this field is non-empty and the editor has text selected at the time of paste, this replacer is used instead of the regular one. If the field is empty, the regular replacer is always used regardless of selection.
+
+This makes it easy to handle two common cases with one rule -- for example, auto-generate a link title from the URL when nothing is selected, but use the selected text as the link title when something is selected:
+
+- **Replacer**: `[🐈‍⬛ $1]($&)` -- used when nothing is selected
+- **Replacer (with selection)**: `[$SEL]($&)` -- used when text is selected
+
+### `$SEL` placeholder
+
+In both replacer fields, you can use the `$SEL` placeholder. It will be replaced with the text currently selected in the editor at the time of paste. If nothing is selected, it is replaced with an empty string.
+
+Example: with the replacer `[$SEL]($&)`, pasting a URL while having "My Link" selected produces `[My Link](https://example.com)`.
 
 ### JavaScript execution rules
 You can also create rules that execute JavaScript code. To do this, select "Script Replacer" from the dropdown menu when creating a new rule.
@@ -32,7 +49,10 @@ You can also create rules that execute JavaScript code. To do this, select "Scri
 The JavaScript code will receive a `ctx` object with the following properties:
 - `ctx.foundText` - the matched substring (convenient for simple cases)
 - `ctx.match` - the full match object with capture groups (result of `string.match(regexp)`)
+- `ctx.selectedText` - the text currently selected in the editor (empty string if nothing is selected)
 - `ctx.debug` - boolean flag indicating if debug mode is enabled (useful for conditional logging)
+
+The full definition of the `ctx` object (class `ScriptContext`) is in [script-context.ts](script-context.ts).
 
 The code should return the replacement string.
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,15 @@ and paste them to a page.
 # Settings
 ![settings-page.png](attachements%2Fsettings-page.png)
 
+## Paste transform enabled
+
+You can globally enable/disable automatic paste transformation with the `Paste Transform Enabled` toggle in plugin settings.
+
+The plugin also provides 3 commands for Command Palette/hotkeys:
+- `Paste Transform: Enable paste transform`
+- `Paste Transform: Disable paste transform`
+- `Paste Transform: Toggle paste transform`
+
 ## Transform rules
 Each rule contains of regex to match and replacer. 
 Replacer can be either regex replacer or a script.

--- a/__mocks__/obsidian.js
+++ b/__mocks__/obsidian.js
@@ -1,9 +1,17 @@
 // Mock for the obsidian module
 module.exports = {
   Plugin: class Plugin {
+    constructor(app, manifest) {
+      this.app = app;
+      this.manifest = manifest;
+    }
     async loadData() {
       return {};
     }
+    async saveData() {}
+    addCommand() {}
+    addSettingTab() {}
+    registerEvent() {}
   },
   PluginSettingTab: class PluginSettingTab {},
   Setting: class Setting {},

--- a/__tests__/advanced.test.ts
+++ b/__tests__/advanced.test.ts
@@ -807,4 +807,223 @@ describe('PasteTransform Advanced Features', () => {
       consoleErrorSpy.mockRestore();
     });
   });
+
+  describe('Selected Text Support', () => {
+    it('should use regular replacer when no text is selected', async () => {
+      plugin.settings.rules = [
+        {
+          pattern: '^https://\\S+$',
+          type: 'replace',
+          replacer: '[LINK]($&)',
+          script: '',
+          enabled: true,
+          name: '',
+          replacerWithSelection: '[$SEL]($&)'
+        }
+      ];
+      plugin.compileRules();
+
+      const {changed, result} = await plugin.applyRules('https://example.com', '');
+      expect(changed).toBe(true);
+      expect(result).toBe('[LINK](https://example.com)');
+    });
+
+    it('should use replacerWithSelection when text is selected', async () => {
+      plugin.settings.rules = [
+        {
+          pattern: '^https://\\S+$',
+          type: 'replace',
+          replacer: '[LINK]($&)',
+          script: '',
+          enabled: true,
+          name: '',
+          replacerWithSelection: '[$SEL]($&)'
+        }
+      ];
+      plugin.compileRules();
+
+      const {changed, result} = await plugin.applyRules('https://example.com', 'My Link');
+      expect(changed).toBe(true);
+      expect(result).toBe('[My Link](https://example.com)');
+    });
+
+    it('should use regular replacer when replacerWithSelection is empty, even if text is selected', async () => {
+      plugin.settings.rules = [
+        {
+          pattern: '^https://\\S+$',
+          type: 'replace',
+          replacer: '[LINK]($&)',
+          script: '',
+          enabled: true,
+          name: '',
+          replacerWithSelection: ''
+        }
+      ];
+      plugin.compileRules();
+
+      const {changed, result} = await plugin.applyRules('https://example.com', 'some text');
+      expect(changed).toBe(true);
+      expect(result).toBe('[LINK](https://example.com)');
+    });
+
+    it('should use regular replacer when replacerWithSelection is undefined', async () => {
+      plugin.settings.rules = [
+        {
+          pattern: '^https://\\S+$',
+          type: 'replace',
+          replacer: '[LINK]($&)',
+          script: '',
+          enabled: true,
+          name: ''
+        }
+      ];
+      plugin.compileRules();
+
+      const {changed, result} = await plugin.applyRules('https://example.com', 'some text');
+      expect(changed).toBe(true);
+      expect(result).toBe('[LINK](https://example.com)');
+    });
+
+    it('should replace $SEL in regular replacer', async () => {
+      plugin.settings.rules = [
+        {
+          pattern: '^(https?://\\S+)$',
+          type: 'replace',
+          replacer: '[$SEL]($1)',
+          script: '',
+          enabled: true,
+          name: '',
+          replacerWithSelection: ''
+        }
+      ];
+      plugin.compileRules();
+
+      const {changed, result} = await plugin.applyRules('https://example.com', 'My Link');
+      expect(changed).toBe(true);
+      expect(result).toBe('[My Link](https://example.com)');
+    });
+
+    it('should replace $SEL in replacerWithSelection', async () => {
+      plugin.settings.rules = [
+        {
+          pattern: '^(https?://\\S+)$',
+          type: 'replace',
+          replacer: '[$1]($&)',
+          script: '',
+          enabled: true,
+          name: '',
+          replacerWithSelection: '[$SEL]($&)'
+        }
+      ];
+      plugin.compileRules();
+
+      const {changed, result} = await plugin.applyRules('https://example.com', 'Click Here');
+      expect(changed).toBe(true);
+      expect(result).toBe('[Click Here](https://example.com)');
+    });
+
+    it('should replace multiple $SEL placeholders', async () => {
+      plugin.settings.rules = [
+        {
+          pattern: '^(https?://\\S+)$',
+          type: 'replace',
+          replacer: '[$1]($&)',
+          script: '',
+          enabled: true,
+          name: '',
+          replacerWithSelection: '[$SEL]($& "$SEL")'
+        }
+      ];
+      plugin.compileRules();
+
+      const {changed, result} = await plugin.applyRules('https://example.com', 'title');
+      expect(changed).toBe(true);
+      expect(result).toBe('[title](https://example.com "title")');
+    });
+
+    it('should replace $SEL with empty string when no selection', async () => {
+      plugin.settings.rules = [
+        {
+          pattern: 'test',
+          type: 'replace',
+          replacer: 'before$SELafter',
+          script: '',
+          enabled: true,
+          name: '',
+          replacerWithSelection: ''
+        }
+      ];
+      plugin.compileRules();
+
+      const {changed, result} = await plugin.applyRules('test', '');
+      expect(changed).toBe(true);
+      expect(result).toBe('beforeafter');
+    });
+
+    it('should provide ctx.selectedText in script rules', async () => {
+      plugin.settings.rules = [
+        {
+          pattern: '^(https?://\\S+)$',
+          type: 'script',
+          replacer: '',
+          script: 'return `[${ctx.selectedText}](${ctx.foundText})`;',
+          enabled: true,
+          name: '',
+          replacerWithSelection: ''
+        }
+      ];
+      plugin.compileRules();
+
+      const {changed, result} = await plugin.applyRules('https://example.com', 'Click Here');
+      expect(changed).toBe(true);
+      expect(result).toBe('[Click Here](https://example.com)');
+    });
+
+    it('should provide empty ctx.selectedText when no selection', async () => {
+      plugin.settings.rules = [
+        {
+          pattern: 'test',
+          type: 'script',
+          replacer: '',
+          script: 'return `sel=[${ctx.selectedText}]`;',
+          enabled: true,
+          name: '',
+          replacerWithSelection: ''
+        }
+      ];
+      plugin.compileRules();
+
+      const {changed, result} = await plugin.applyRules('test', '');
+      expect(changed).toBe(true);
+      expect(result).toBe('sel=[]');
+    });
+
+    it('should preserve selectedText across chained rules', async () => {
+      plugin.settings.rules = [
+        {
+          pattern: '^(.+)$',
+          type: 'replace',
+          replacer: 'STEP1:$1',
+          script: '',
+          enabled: true,
+          name: '',
+          replacerWithSelection: ''
+        },
+        {
+          pattern: '^STEP1:(.+)$',
+          type: 'replace',
+          replacer: 'NO_SELECTION',
+          script: '',
+          enabled: true,
+          name: '',
+          replacerWithSelection: '[$SEL]($1)'
+        }
+      ];
+      plugin.compileRules();
+
+      const {changed, result} = await plugin.applyRules('https://example.com', 'My Link');
+      expect(changed).toBe(true);
+      expect(result).toBe('[My Link](https://example.com)');
+    });
+  });
 });

--- a/__tests__/advanced.test.ts
+++ b/__tests__/advanced.test.ts
@@ -808,6 +808,101 @@ describe('PasteTransform Advanced Features', () => {
     });
   });
 
+  describe('Paste transform enabled state', () => {
+    it('should not process paste when paste transform is disabled', async () => {
+      plugin.settings.rules = [
+        {
+          pattern: '^https://example.com$',
+          type: 'replace',
+          replacer: '[LINK](https://example.com)',
+          script: '',
+          enabled: true,
+          name: ''
+        }
+      ];
+      plugin.compileRules();
+      plugin.settings.pasteTransformEnabled = false;
+
+      const replaceSelection = jest.fn();
+      (plugin as any).app.workspace = {
+        activeEditor: {
+          editor: {
+            getSelection: () => '',
+            replaceSelection
+          }
+        }
+      };
+
+      const preventDefault = jest.fn();
+      const event = {
+        defaultPrevented: false,
+        preventDefault,
+        clipboardData: {
+          types: ['text/plain'],
+          getData: () => 'https://example.com'
+        }
+      } as unknown as ClipboardEvent;
+
+      await plugin.onPaste(event);
+
+      expect(preventDefault).not.toHaveBeenCalled();
+      expect(replaceSelection).not.toHaveBeenCalled();
+    });
+
+    it('should process paste when paste transform is enabled', async () => {
+      plugin.settings.rules = [
+        {
+          pattern: '^https://example.com$',
+          type: 'replace',
+          replacer: '[LINK](https://example.com)',
+          script: '',
+          enabled: true,
+          name: ''
+        }
+      ];
+      plugin.compileRules();
+      plugin.settings.pasteTransformEnabled = true;
+
+      const replaceSelection = jest.fn();
+      (plugin as any).app.workspace = {
+        activeEditor: {
+          editor: {
+            getSelection: () => '',
+            replaceSelection
+          }
+        }
+      };
+
+      const preventDefault = jest.fn();
+      const event = {
+        defaultPrevented: false,
+        preventDefault,
+        clipboardData: {
+          types: ['text/plain'],
+          getData: () => 'https://example.com'
+        }
+      } as unknown as ClipboardEvent;
+
+      await plugin.onPaste(event);
+
+      expect(preventDefault).toHaveBeenCalledTimes(1);
+      expect(replaceSelection).toHaveBeenCalledWith('[LINK](https://example.com)');
+    });
+
+    it('should save only when enabled state actually changes', async () => {
+      const saveDataSpy = jest.spyOn(plugin, 'saveData').mockResolvedValue(undefined);
+
+      await plugin.setPasteTransformEnabled(true);
+      expect(saveDataSpy).not.toHaveBeenCalled();
+
+      await plugin.setPasteTransformEnabled(false);
+      expect(saveDataSpy).toHaveBeenCalledTimes(1);
+
+      await plugin.togglePasteTransformEnabled();
+      expect(saveDataSpy).toHaveBeenCalledTimes(2);
+    });
+  });
+
   describe('Selected Text Support', () => {
     it('should use regular replacer when no text is selected', async () => {
       plugin.settings.rules = [

--- a/__tests__/advanced.test.ts
+++ b/__tests__/advanced.test.ts
@@ -47,7 +47,8 @@ describe('PasteTransform Advanced Features', () => {
 				type: 'replace',
 				replacer: '$1',
 				script: "",
-				enabled: true
+				enabled: true,
+				name: ""
 			}
 		];
 		plugin.compileRules();
@@ -64,7 +65,8 @@ describe('PasteTransform Advanced Features', () => {
         type: 'script',
         replacer: '',
         script: 'return ctx.match[1].toUpperCase();',
-        enabled: true
+        enabled: true,
+        name: ""
       }
     ];
     plugin.compileRules();
@@ -84,7 +86,8 @@ describe('PasteTransform Advanced Features', () => {
         type: 'script',
         replacer: '',
         script: 'throw new Error("Test error");',
-        enabled: true
+        enabled: true,
+        name: ""
       }
     ];
     plugin.compileRules();
@@ -96,7 +99,7 @@ describe('PasteTransform Advanced Features', () => {
     
     // Verify that the error was logged
     expect(consoleErrorSpy).toHaveBeenCalledWith(
-      "Error executing script for rule #1:",
+      "Error executing script for Rule #1:",
       expect.any(Error)
     );
 
@@ -117,7 +120,8 @@ describe('PasteTransform Advanced Features', () => {
             }, 10);
           });
         `,
-        enabled: true
+        enabled: true,
+        name: ""
       }
     ];
     plugin.compileRules();
@@ -140,7 +144,8 @@ describe('PasteTransform Advanced Features', () => {
           const input = ctx.match[1];
           return input.toUpperCase();
         `,
-        enabled: true
+        enabled: true,
+        name: ""
       }
     ];
     plugin.compileRules();
@@ -164,7 +169,8 @@ describe('PasteTransform Advanced Features', () => {
           await new Promise(resolve => setTimeout(resolve, 1));
           throw new Error("Test error");
         `,
-        enabled: true
+        enabled: true,
+        name: ""
       }
     ];
     plugin.compileRules();
@@ -176,7 +182,7 @@ describe('PasteTransform Advanced Features', () => {
     
     // Verify that the error was logged
     expect(consoleErrorSpy).toHaveBeenCalledWith(
-      "Error executing script for rule #1:",
+      "Error executing script for Rule #1:",
       expect.any(Error)
     );
 
@@ -208,7 +214,8 @@ describe('PasteTransform Advanced Features', () => {
           "const data = await response.json();\n" +
           "const title = data.title;\n" +
           "return `[${ctx.match[2]}#${ctx.match[3]}: ${title}](${ctx.foundText})`;",
-        enabled: true
+        enabled: true,
+        name: ""
       }
     ];
     plugin.compileRules();
@@ -235,7 +242,8 @@ describe('PasteTransform Advanced Features', () => {
         type: 'script',
         replacer: '',
         script: 'throw new Error("Test error message");',
-        enabled: true
+        enabled: true,
+        name: ""
       }
     ];
     plugin.compileRules();
@@ -265,7 +273,8 @@ describe('PasteTransform Advanced Features', () => {
           type: 'replace',
           replacer: '[GitHub: $1]',
           script: '',
-          enabled: true
+          enabled: true,
+          name: ""
         }
       ];
       plugin.compileRules();
@@ -284,7 +293,8 @@ describe('PasteTransform Advanced Features', () => {
           type: 'script',
           replacer: '',
           script: 'return "RESULT" + ctx.match[1];',
-          enabled: true
+          enabled: true,
+          name: ""
         }
       ];
       plugin.compileRules();
@@ -306,7 +316,8 @@ describe('PasteTransform Advanced Features', () => {
             await new Promise(resolve => setTimeout(resolve, 5));
             return "ASYNC" + ctx.match[1];
           `,
-          enabled: true
+          enabled: true,
+          name: ""
         }
       ];
       plugin.compileRules();
@@ -325,21 +336,24 @@ describe('PasteTransform Advanced Features', () => {
           type: 'replace',
           replacer: 'STEP1',
           script: '',
-          enabled: true
+          enabled: true,
+          name: ""
         },
         {
           pattern: 'STEP1',
           type: 'replace',
           replacer: 'STEP2',
           script: '',
-          enabled: true
+          enabled: true,
+          name: ""
         },
         {
           pattern: 'STEP2',
           type: 'script',
           replacer: '',
           script: 'return "FINAL";',
-          enabled: true
+          enabled: true,
+          name: ""
         }
       ];
       plugin.compileRules();
@@ -360,21 +374,24 @@ describe('PasteTransform Advanced Features', () => {
           type: 'replace',
           replacer: 'RESULT1',
           script: '',
-          enabled: true
+          enabled: true,
+          name: ""
         },
         {
           pattern: 'RESULT1',
           type: 'script',
           replacer: '',
           script: 'throw new Error("Rule 2 error");',
-          enabled: true
+          enabled: true,
+          name: ""
         },
         {
           pattern: 'RESULT1',
           type: 'replace',
           replacer: 'RESULT3',
           script: '',
-          enabled: true
+          enabled: true,
+          name: ""
         }
       ];
       plugin.compileRules();
@@ -401,14 +418,16 @@ describe('PasteTransform Advanced Features', () => {
           type: 'replace',
           replacer: 'A',
           script: '',
-          enabled: true
+          enabled: true,
+          name: ""
         },
         {
           pattern: 'A',
           type: 'replace',
           replacer: 'AA',
           script: '',
-          enabled: true
+          enabled: true,
+          name: ""
         }
       ];
       plugin.compileRules();
@@ -426,7 +445,8 @@ describe('PasteTransform Advanced Features', () => {
           type: 'replace',
           replacer: 'REPLACED',
           script: '',
-          enabled: true
+          enabled: true,
+          name: ""
         }
       ];
       plugin.compileRules();
@@ -473,7 +493,8 @@ describe('PasteTransform Advanced Features', () => {
               await new Promise(resolve => setTimeout(resolve, 3500));
               return ctx.match[1].toUpperCase();
             `,
-            enabled: true
+            enabled: true,
+            name: ""
           }
         ];
         plugin.compileRules();
@@ -524,7 +545,8 @@ describe('PasteTransform Advanced Features', () => {
               await new Promise(resolve => setTimeout(resolve, 100));
               return ctx.match[1].toUpperCase();
             `,
-            enabled: true
+            enabled: true,
+            name: ""
           }
         ];
         plugin.compileRules();
@@ -573,7 +595,8 @@ describe('PasteTransform Advanced Features', () => {
               // Very fast operation - completes immediately
               return ctx.match[1].toUpperCase();
             `,
-            enabled: true
+            enabled: true,
+            name: ""
           }
         ];
         plugin.compileRules();
@@ -624,7 +647,8 @@ describe('PasteTransform Advanced Features', () => {
             script: `
               throw new Error("Test error");
             `,
-            enabled: true
+            enabled: true,
+            name: ""
           }
         ];
         plugin.compileRules();
@@ -683,7 +707,8 @@ describe('PasteTransform Advanced Features', () => {
               await new Promise(resolve => setTimeout(resolve, 3500));
               return ctx.match[1].toUpperCase();
             `,
-            enabled: true
+            enabled: true,
+            name: ""
           }
         ];
         plugin.compileRules();
@@ -727,7 +752,8 @@ describe('PasteTransform Advanced Features', () => {
           type: 'script',
           replacer: '',
           script: 'throw new Error("Script failed");',
-          enabled: true
+          enabled: true,
+          name: ""
         }
       ];
       plugin.compileRules();
@@ -758,14 +784,16 @@ describe('PasteTransform Advanced Features', () => {
           type: 'replace',
           replacer: 'replacement',
           script: '',
-          enabled: true
+          enabled: true,
+          name: ""
         },
         {
           pattern: 'valid',
           type: 'replace',
           replacer: 'VALID',
           script: '',
-          enabled: true
+          enabled: true,
+          name: ""
         }
       ];
       

--- a/__tests__/test-backward-compatibility.ts
+++ b/__tests__/test-backward-compatibility.ts
@@ -45,6 +45,7 @@ describe('PasteTransform Backward Compatibility', () => {
     expect(plugin.settings.settingsFormatVersion).toBe(2);
     expect(plugin.settings.rules).toHaveLength(2);
     expect(plugin.settings.scriptSecurityWarningAccepted).toBe(false);
+    expect(plugin.settings.pasteTransformEnabled).toBe(true);
     
     // Check first rule
     expect(plugin.settings.rules[0]).toEqual({
@@ -189,5 +190,37 @@ describe('PasteTransform Backward Compatibility', () => {
 
     // Check that scriptSecurityWarningAccepted is false by default
     expect(plugin.settings.scriptSecurityWarningAccepted).toBe(false);
+    expect(plugin.settings.pasteTransformEnabled).toBe(true);
+  });
+
+  it('should set pasteTransformEnabled to true for old v2 settings without this field', async () => {
+    const v2WithoutPasteToggle = {
+      rules: [],
+      settingsFormatVersion: 2,
+      debugMode: false,
+      showRuleNotifications: false,
+      scriptSecurityWarningAccepted: false
+    };
+
+    jest.spyOn(plugin, 'loadData').mockResolvedValue(v2WithoutPasteToggle);
+    await plugin.loadSettings();
+
+    expect(plugin.settings.pasteTransformEnabled).toBe(true);
+  });
+
+  it('should preserve explicit pasteTransformEnabled value from saved v2 settings', async () => {
+    const v2WithPasteToggleOff = {
+      rules: [],
+      settingsFormatVersion: 2,
+      debugMode: false,
+      showRuleNotifications: false,
+      scriptSecurityWarningAccepted: false,
+      pasteTransformEnabled: false
+    };
+
+    jest.spyOn(plugin, 'loadData').mockResolvedValue(v2WithPasteToggleOff);
+    await plugin.loadSettings();
+
+    expect(plugin.settings.pasteTransformEnabled).toBe(false);
   });
 });

--- a/__tests__/test-backward-compatibility.ts
+++ b/__tests__/test-backward-compatibility.ts
@@ -52,7 +52,8 @@ describe('PasteTransform Backward Compatibility', () => {
       type: 'replace',
       replacer: 'SYNC:$1',
       script: '',
-      enabled: true
+      enabled: true,
+      name: ''
     });
     
     // Check second rule
@@ -61,7 +62,8 @@ describe('PasteTransform Backward Compatibility', () => {
       type: 'replace',
       replacer: 'ERROR:$1',
       script: '',
-      enabled: true
+      enabled: true,
+      name: ''
     });
   });
 
@@ -125,7 +127,8 @@ describe('PasteTransform Backward Compatibility', () => {
           type: 'script',
           replacer: '',
           script: 'return "TRANSFORMED:" + ctx.foundText;',
-          enabled: true
+          enabled: true,
+          name: ''
         }
       ],
       settingsFormatVersion: 2,
@@ -155,7 +158,8 @@ describe('PasteTransform Backward Compatibility', () => {
           type: 'script',
           replacer: '',
           script: 'return "TRANSFORMED:" + ctx.foundText;',
-          enabled: true
+          enabled: true,
+          name: ''
         }
       ],
       settingsFormatVersion: 2,

--- a/agents/architecture.md
+++ b/agents/architecture.md
@@ -11,7 +11,8 @@ Version scheme: `0.X.Y` (X = breaking changes, Y = non-breaking)
 ## File Structure
 
 ```
-main.ts                     Main plugin source (~880 lines, single-file plugin)
+main.ts                     Main plugin source (single-file plugin, imports script-context.ts)
+script-context.ts           ScriptContext class — the `ctx` object passed to script rules
 styles.css                  Plugin UI styles (drag-and-drop, test area, rule layout)
 manifest.json               Obsidian plugin manifest (id, version, minAppVersion)
 versions.json               Plugin version -> minimum Obsidian version mapping
@@ -37,7 +38,7 @@ __tests__/
 | `Rule` | interface | Single transform rule: pattern, type, replacer, script, enabled |
 | `PasteTransformSettingsV2` | interface | Current settings format: rules[], debugMode, showRuleNotifications, scriptSecurityWarningAccepted |
 | `PasteTransformSettingsV1` | interface | Legacy settings (patterns[] + replacers[]), converted on load |
-| `ScriptContext` | class | Context passed to script rules: `match`, `foundText`, `debug` |
+| `ScriptContext` | class | Context passed to script rules: `match`, `foundText`, `selectedText`, `debug` — defined in `script-context.ts` |
 | `ReplaceRule` | class | Compiled rule: regex compilation, script execution with timeout, error handling |
 | `PasteTransform` | class (default export) | Plugin class: paste event handler, rule application, settings load/save |
 | `PasteTransformSettingsTab` | class | Settings UI: security toggle, debug toggle, test area, rules list with drag-and-drop |

--- a/agents/architecture.md
+++ b/agents/architecture.md
@@ -1,0 +1,92 @@
+# Project Architecture
+
+## Overview
+
+**Paste Transform** is an Obsidian plugin that intercepts paste events and transforms pasted plain text using regex or JavaScript rules.
+
+Repository: `rekby/obsidian-paste-transform`
+License: Apache-2.0
+Version scheme: `0.X.Y` (X = breaking changes, Y = non-breaking)
+
+## File Structure
+
+```
+main.ts                     Main plugin source (~880 lines, single-file plugin)
+styles.css                  Plugin UI styles (drag-and-drop, test area, rule layout)
+manifest.json               Obsidian plugin manifest (id, version, minAppVersion)
+versions.json               Plugin version -> minimum Obsidian version mapping
+package.json                Dependencies and scripts
+tsconfig.json               TypeScript config
+esbuild.config.mjs          Build config (esbuild, entry: main.ts -> main.js)
+version-bump.mjs            Script for npm version hook (updates manifest.json, versions.json)
+jest.config.js              Jest config (ts-jest, node environment)
+__mocks__/obsidian.js        Mocks for Obsidian API (Plugin, Setting, Notice, etc.)
+__tests__/
+  advanced.test.ts           Feature tests (regex, scripts, async, errors, timeouts, chaining)
+  test-backward-compatibility.ts  Settings migration v1->v2, script security flag
+.github/workflows/
+  test.yml                   CI: build + test on PR/push to main/master
+  publish.yml                Release: manual workflow_dispatch, version bump + GitHub release
+```
+
+## Key Types and Classes (main.ts)
+
+| Symbol | Kind | Purpose |
+|--------|------|---------|
+| `RuleType` | type | `'replace' \| 'script'` |
+| `Rule` | interface | Single transform rule: pattern, type, replacer, script, enabled |
+| `PasteTransformSettingsV2` | interface | Current settings format: rules[], debugMode, showRuleNotifications, scriptSecurityWarningAccepted |
+| `PasteTransformSettingsV1` | interface | Legacy settings (patterns[] + replacers[]), converted on load |
+| `ScriptContext` | class | Context passed to script rules: `match`, `foundText`, `debug` |
+| `ReplaceRule` | class | Compiled rule: regex compilation, script execution with timeout, error handling |
+| `PasteTransform` | class (default export) | Plugin class: paste event handler, rule application, settings load/save |
+| `PasteTransformSettingsTab` | class | Settings UI: security toggle, debug toggle, test area, rules list with drag-and-drop |
+
+## Data Flow
+
+```
+Paste event
+  -> PasteTransform.onPaste()
+     -> Check: plain text only, not already prevented
+     -> Synchronous check: any rule matches?
+        -> Yes: preventDefault() immediately
+     -> applyRules(): sequential rule application
+        -> Each rule: executeRule() -> regex replace or script execution
+     -> Insert transformed text via editor.replaceSelection()
+```
+
+## Build and Scripts
+
+| Command | Purpose |
+|---------|---------|
+| `npm run dev` | Watch build (esbuild, dev mode with sourcemaps) |
+| `npm run build` | `tsc -noEmit -skipLibCheck` + esbuild production build |
+| `npm test` | Jest tests |
+| `npm version <minor\|patch>` | Bumps version in package.json, manifest.json, versions.json |
+
+## CI/CD
+
+- **test.yml**: Runs on PRs and pushes to `main`/`master`. Steps: checkout -> Node 18 -> `npm ci` -> `npm run build` -> `npm test`.
+- **publish.yml**: Manual trigger (`workflow_dispatch`). Inputs: version part (minor/patch), optional release title. Steps: version bump -> build -> push tag -> create GitHub release with `main.js`, `manifest.json`, `styles.css`.
+
+## Default Rules
+
+The plugin ships with 4 default rules (2 enabled, 2 disabled):
+1. GitHub repo link -> emoji + repo name (enabled, regex)
+2. Wikipedia link -> emoji + article name (enabled, regex)
+3. GitHub issue link -> fetch title from API (disabled, script)
+4. GitHub PR link -> fetch title from API (disabled, script)
+
+---
+
+## How to Update This Document
+
+This section is for agents that need to keep the architecture doc in sync with the codebase.
+
+**When to update**: new files added/removed, types or classes renamed/split/merged, build or CI config changed, new dependencies added, default rules changed, data flow changed.
+
+**How**:
+1. Read the current codebase (start with `main.ts`, `package.json`, file listing).
+2. Compare each section above with the actual code.
+3. Update only sections that diverged. Do not rewrite unchanged sections.
+4. Keep the same structure, table format, and level of detail.

--- a/agents/create-pr.md
+++ b/agents/create-pr.md
@@ -1,0 +1,49 @@
+# Create a Pull Request
+
+Step-by-step workflow for preparing and creating a PR in this repository.
+
+## Conventions
+
+- **Default branch**: `master`
+- **Branch naming**: descriptive, lowercase with hyphens (e.g. `add-timeout-setting`, `fix-drag-drop`)
+- **Commit style**: imperative, lowercase, short single-line messages (e.g. `fixed infinite cancel dialogs`, `add debug mode`)
+- **No PR template** exists — write a clear description of what changed and why.
+
+## Steps
+
+### 1. Verify code changes
+
+All functional changes are complete and working locally.
+
+### 2. Build
+
+```bash
+npm run build
+```
+
+Must pass (type-check via `tsc` + production esbuild bundle).
+
+### 3. Test
+
+```bash
+npm test
+```
+
+All tests must pass. See [agents/testing.md](testing.md) for details on writing new tests.
+
+### 4. Update documentation
+
+Follow the instructions in [agents/update-documentation.md](update-documentation.md).
+
+### 5. Commit
+
+Commit all changes (code + documentation) following the commit conventions above.
+
+### 6. Push and create PR
+
+```bash
+git push -u origin HEAD
+gh pr create --title "<descriptive title>" --body "<description of changes>"
+```
+
+Target branch: `master`.

--- a/agents/testing.md
+++ b/agents/testing.md
@@ -1,0 +1,60 @@
+# Testing
+
+## Quick Start
+
+```bash
+npm test          # run all tests
+npm run build     # type-check (tsc) + production build (esbuild)
+```
+
+Both commands must pass before creating a PR. CI (`test.yml`) runs them automatically on every PR and push to `main`/`master`.
+
+## Framework
+
+- **Jest** with **ts-jest** preset (`jest.config.js`).
+- Environment: `node`.
+- `forceExit: true` to avoid hanging on background timers from script timeout tests.
+
+## Test Files
+
+| File | What it covers |
+|------|---------------|
+| `__tests__/advanced.test.ts` | Regex rules, script rules, async scripts, error handling, multiple matches, rule chaining, script timeout notifications, invalid regex patterns, error recovery |
+| `__tests__/test-backward-compatibility.ts` | Settings migration from v1 to v2, script security flag behavior (block/allow execution) |
+
+## Mocks
+
+`__mocks__/obsidian.js` provides stubs for Obsidian API classes used by the plugin:
+- `Plugin` (with `loadData`/`saveData` stubs)
+- `PluginSettingTab`
+- `Setting`, `TextAreaComponent`, `DropdownComponent`, `ButtonComponent`, `TextComponent`
+- `App`, `Notice`, `setIcon`
+
+`advanced.test.ts` additionally overrides `Notice` with a tracked mock to assert error/timeout notifications.
+
+For tests that need `fetch`, mock it via `global.fetch = jest.fn(...)`.
+
+## How Tests Work
+
+Tests instantiate `PasteTransform` directly with mock app/manifest, call `loadSettings()`, configure `settings.rules`, call `compileRules()`, then assert results of `applyRules(input)`.
+
+Typical pattern:
+
+```typescript
+plugin.settings.rules = [
+  { pattern: '^test:(.+)$', type: 'replace', replacer: '$1', script: '', enabled: true }
+];
+plugin.compileRules();
+
+const { changed, result } = await plugin.applyRules('test:abc');
+expect(changed).toBe(true);
+expect(result).toBe('abc');
+```
+
+## Writing New Tests
+
+1. Add tests to existing files or create a new `__tests__/*.test.ts` file.
+2. Follow the existing pattern: `beforeEach` with mock setup, configure rules, `compileRules()`, assert `applyRules()`.
+3. For script rules, set `plugin.settings.scriptSecurityWarningAccepted = true`.
+4. For timeout tests, use `jest.useFakeTimers()` and `jest.runAllTimersAsync()`.
+5. For error tests, spy on `console.error` with `mockImplementation(() => {})` to suppress noise.

--- a/agents/update-documentation.md
+++ b/agents/update-documentation.md
@@ -1,0 +1,50 @@
+# Update Documentation
+
+Instructions for updating `README.md` and `agents/*.md` after code changes.
+
+## Procedure
+
+1. Read the current `README.md`.
+2. Read the current `agents/*.md`.
+3. Run `git diff master...HEAD` to see all changes in the current branch.
+4. Determine which sections of each document are affected by the diff.
+5. Make minimal, targeted edits to affected sections only.
+
+## README Structure
+
+The current `README.md` has the following sections (in order):
+
+1. **Header** — project name and one-line description
+2. **Usage** — paste example with screenshot
+3. **Settings** — screenshot of settings page
+4. **Transform rules** — regex rules explanation, links to MDN docs
+5. **JavaScript execution rules** — `ctx` object API (`foundText`, `match`, `debug`), code examples (simple, capture groups, async/fetch, debug mode)
+6. **Try result** — test textarea description
+7. **Resize text area** — UI hint
+8. **Installation** — community plugins link + manual installation
+9. **Versioning** — `0.X.Y` scheme explanation
+
+## Architecture Doc Structure
+
+See [agents/architecture.md](architecture.md). It covers: file structure, key types/classes, data flow, build/scripts, CI/CD, default rules. Also see the "How to Update This Document" section at the bottom of that file.
+
+## When to Update
+
+- New feature or setting added
+- Existing feature behavior changed
+- Script context API (`ctx`) changed (new properties, renamed fields)
+- New rule type added
+- Default rules changed
+- Installation process changed
+- Version scheme changed
+- Files added/removed, types renamed/split/merged
+- Build or CI config changed
+
+## Rules
+
+- Keep the existing tone in README: informal, concise, with code examples where appropriate.
+- Keep the same structure and detail level in architecture doc.
+- If UI changed, note that screenshots (`attachements/` folder) may need updating, but do not generate screenshots.
+- Do not rewrite unchanged sections.
+- Do not change formatting style or add/remove sections unless the feature requires it.
+- Do not add agent-specific comments or metadata to documentation files.

--- a/main.ts
+++ b/main.ts
@@ -9,6 +9,15 @@ const NOTICE_DURATION_SHORT = 3000;
 const NOTICE_DURATION_NORMAL = 5000;
 const NOTICE_DURATION_LONG = 10000;
 
+function getDefaultRuleName(ruleNumber: number): string {
+	return `Rule #${ruleNumber}`;
+}
+
+function getRuleDisplayName(ruleName: string, ruleNumber: number): string {
+	const trimmedName = ruleName.trim();
+	return trimmedName || getDefaultRuleName(ruleNumber);
+}
+
 // Define the type of rule
 type RuleType = 'replace' | 'script';
 
@@ -396,7 +405,7 @@ export default class PasteTransform extends Plugin {
 		for (let i = 0; i < this.settings.rules.length; i++) {
 			const rule = this.settings.rules[i];
 			const ruleNumber = i + 1; // Rule numbers start from 1 for users (based on position in settings)
-			const displayName = rule.name || `Rule #${ruleNumber}`;
+			const displayName = getRuleDisplayName(rule.name, ruleNumber);
 			
 			if (rule.enabled) {
 				// Skip script rules if security warning not accepted
@@ -753,7 +762,7 @@ class PasteTransformSettingsTab extends PluginSettingTab {
 		const ruleNumber = index + 1;
 		const nameInputContainer = headerRow.createDiv({cls: 'rule-name-container'});
 		const nameInput = new TextComponent(nameInputContainer);
-		nameInput.setPlaceholder(`Rule #${ruleNumber}`);
+		nameInput.setPlaceholder(getDefaultRuleName(ruleNumber));
 		nameInput.setValue(rule.name);
 		nameInput.onChange(async (value) => {
 			this.plugin.settings.rules[index].name = value;
@@ -795,8 +804,9 @@ class PasteTransformSettingsTab extends PluginSettingTab {
 		deleteButton.setIcon('trash');
 		deleteButton.setTooltip('Delete rule');
 		deleteButton.onClick(async () => {
+			const ruleLabel = getRuleDisplayName(rule.name, ruleNumber);
 			const confirmed = confirm(
-				`Delete rule #${ruleNumber}?\n\n` +
+				`Delete rule ${ruleLabel}?\n\n` +
 				`Regex: ${rule.pattern}`
 			);
 			if (confirmed) {

--- a/main.ts
+++ b/main.ts
@@ -658,7 +658,7 @@ class PasteTransformSettingsTab extends PluginSettingTab {
 		
 		const renderRule = (rule: Rule, index: number) => {
 			const ruleContainer = rulesContainer.createDiv({cls: 'rule-container'});
-			ruleContainer.draggable = true;
+			ruleContainer.draggable = false;
 			
 			// Check if this is a script rule and security warning is not accepted
 			const isScriptRuleLocked = rule.type === 'script' && !this.plugin.settings.scriptSecurityWarningAccepted;
@@ -669,6 +669,12 @@ class PasteTransformSettingsTab extends PluginSettingTab {
 			// Drag handle
 			const dragHandle = headerRow.createDiv({cls: 'drag-handle'});
 			setIcon(dragHandle, 'grip-vertical');
+			dragHandle.addEventListener('mousedown', () => {
+				ruleContainer.draggable = true;
+			});
+			dragHandle.addEventListener('mouseup', () => {
+				ruleContainer.draggable = false;
+			});
 			
 		// Rule number / name input
 		const ruleNumber = index + 1;
@@ -905,6 +911,7 @@ class PasteTransformSettingsTab extends PluginSettingTab {
 					el.removeClass('drag-over-bottom');
 				});
 				this.draggedIndex = null;
+				ruleContainer.draggable = false;
 			});
 		};
 		

--- a/main.ts
+++ b/main.ts
@@ -30,6 +30,7 @@ interface PasteTransformSettingsV2 {
 	debugMode: boolean,
 	showRuleNotifications: boolean,
 	scriptSecurityWarningAccepted: boolean,
+	pasteTransformEnabled: boolean,
 }
 
 // Old settings format (version 1)
@@ -95,6 +96,7 @@ const DEFAULT_SETTINGS: PasteTransformSettingsV2 = {
 	debugMode: false,
 	showRuleNotifications: true,
 	scriptSecurityWarningAccepted: false,
+	pasteTransformEnabled: true,
 }
 
 class ReplaceRule {
@@ -218,6 +220,30 @@ export default class PasteTransform extends Plugin {
 		// This adds a settings tab so the user can configure various aspects of the plugin
 		this.addSettingTab(new PasteTransformSettingsTab(this.app, this));
 
+		this.addCommand({
+			id: 'enable-paste-transform',
+			name: 'Enable paste transform',
+			callback: async () => {
+				await this.setPasteTransformEnabled(true, true);
+			}
+		});
+
+		this.addCommand({
+			id: 'disable-paste-transform',
+			name: 'Disable paste transform',
+			callback: async () => {
+				await this.setPasteTransformEnabled(false, true);
+			}
+		});
+
+		this.addCommand({
+			id: 'toggle-paste-transform',
+			name: 'Toggle paste transform',
+			callback: async () => {
+				await this.togglePasteTransformEnabled(true);
+			}
+		});
+
 		this.registerEvent(this.app.workspace.on("editor-paste", event => this.onPaste(event)));
 	}
 
@@ -225,6 +251,13 @@ export default class PasteTransform extends Plugin {
 		if(event.defaultPrevented){
 			if (this.settings.debugMode) {
 				console.log("It doesn't try to apply rules because event prevented already.");
+			}
+			return;
+		}
+
+		if (!this.settings.pasteTransformEnabled) {
+			if (this.settings.debugMode) {
+				console.log("Paste transform is disabled. Skipping rule application.");
 			}
 			return;
 		}
@@ -321,7 +354,8 @@ export default class PasteTransform extends Plugin {
 				settingsFormatVersion: 2, // Update to new format version
 				debugMode: oldSettings.debugMode || false,
 				showRuleNotifications: true,
-				scriptSecurityWarningAccepted: false
+				scriptSecurityWarningAccepted: false,
+				pasteTransformEnabled: true,
 			};
 		} else {
 			// Use default settings merged with loaded data (new format)
@@ -330,6 +364,11 @@ export default class PasteTransform extends Plugin {
 		// Ensure scriptSecurityWarningAccepted is set (for backward compatibility with v2 without this field)
 		if (this.settings.scriptSecurityWarningAccepted === undefined) {
 			this.settings.scriptSecurityWarningAccepted = false;
+		}
+
+		// Ensure pasteTransformEnabled is set (for backward compatibility with older settings)
+		if (this.settings.pasteTransformEnabled === undefined) {
+			this.settings.pasteTransformEnabled = true;
 		}
 	}
 	
@@ -381,6 +420,27 @@ export default class PasteTransform extends Plugin {
 
 	async saveSettings() {
 		await this.saveData(this.settings);
+	}
+
+	public async setPasteTransformEnabled(enabled: boolean, showNotice: boolean = false): Promise<boolean> {
+		if (this.settings.pasteTransformEnabled === enabled) {
+			if (showNotice) {
+				new Notice(`Paste transform is already ${enabled ? 'enabled' : 'disabled'}`, NOTICE_DURATION_SHORT);
+			}
+			return false;
+		}
+
+		this.settings.pasteTransformEnabled = enabled;
+		await this.saveSettings();
+
+		if (showNotice) {
+			new Notice(`Paste transform ${enabled ? 'enabled' : 'disabled'}`, NOTICE_DURATION_SHORT);
+		}
+		return true;
+	}
+
+	public async togglePasteTransformEnabled(showNotice: boolean = false): Promise<boolean> {
+		return await this.setPasteTransformEnabled(!this.settings.pasteTransformEnabled, showNotice);
 	}
 
 	// Execute a specific rule on all matches in the source
@@ -510,11 +570,24 @@ class PasteTransformSettingsTab extends PluginSettingTab {
 		const {containerEl} = this;
 		containerEl.empty();
 
+		this.renderPasteTransformToggle(containerEl);
 		this.renderSecurityToggle(containerEl);
 		this.renderDebugToggle(containerEl);
 		this.renderNotificationsToggle(containerEl);
 		this.renderTestSection(containerEl);
 		this.renderRulesSection(containerEl);
+	}
+
+	private renderPasteTransformToggle(containerEl: HTMLElement): void {
+		new Setting(containerEl)
+			.setName("Paste Transform Enabled")
+			.setDesc("Enable or disable automatic paste transformation by rules.")
+			.addToggle(toggle => {
+				toggle.setValue(this.plugin.settings.pasteTransformEnabled);
+				toggle.onChange(async (value) => {
+					await this.plugin.setPasteTransformEnabled(value);
+				});
+			});
 	}
 
 	private renderSecurityToggle(containerEl: HTMLElement): void {

--- a/main.ts
+++ b/main.ts
@@ -796,7 +796,7 @@ class PasteTransformSettingsTab extends PluginSettingTab {
 		deleteButton.setTooltip('Delete rule');
 		deleteButton.onClick(async () => {
 			const confirmed = confirm(
-				`Удалить правило #${ruleNumber}?\n\n` +
+				`Delete rule #${ruleNumber}?\n\n` +
 				`Regex: ${rule.pattern}`
 			);
 			if (confirmed) {

--- a/main.ts
+++ b/main.ts
@@ -1,4 +1,5 @@
 import {App, Plugin, PluginSettingTab, Setting, TextAreaComponent, DropdownComponent, ButtonComponent, TextComponent, Notice, setIcon} from 'obsidian';
+import {ScriptContext} from './script-context';
 
 // Script execution timeout in milliseconds
 const SCRIPT_TIMEOUT_MS = 3000;
@@ -19,6 +20,7 @@ interface Rule {
 	script: string;   // Used when type is 'script'
 	enabled: boolean; // Whether the rule is enabled
 	name: string;     // Optional name for the rule
+	replacerWithSelection?: string; // Replacer used when there is selected text; if empty, regular replacer is used
 }
 
 
@@ -46,7 +48,8 @@ const DEFAULT_SETTINGS: PasteTransformSettingsV2 = {
 			replacer: "[🐈‍⬛ $1]($&)",
 			script: "",
 			enabled: true,
-			name: ""
+			name: "",
+			replacerWithSelection: "[🐈‍⬛ $SEL]($&)"
 		},
 		{
 			pattern: "^https://\\w+.wikipedia.org/wiki/([^\\s]+)$",
@@ -54,33 +57,38 @@ const DEFAULT_SETTINGS: PasteTransformSettingsV2 = {
 			replacer: "[📖 $1]($&)",
 			script: "",
 			enabled: true,
-			name: ""
+			name: "",
+			replacerWithSelection: "[📖 $SEL]($&)"
 		},
 		{
 			pattern: "^https://github.com/([^/]+)/([^/]+)/issues/(\\d+)$",
 			type: 'script',
 			replacer: "",
 			script: "" +
+				"// ctx fields: https://github.com/rekby/obsidian-paste-transform/blob/master/script-context.ts\n" +
 				"const url=`https://api.github.com/repos/${ctx.match[1]}/${ctx.match[2]}/issues/${ctx.match[3]}`\n" +
 				"const response = await fetch(url);\n" +
 				"const data = await response.json();\n" +
 				"const title = data.title;\n" +
 				"return `[${ctx.match[2]}#${ctx.match[3]}: ${title}](${ctx.foundText})`;",
 			enabled: false,
-			name: ""
+			name: "",
+			replacerWithSelection: ""
 		},
 		{
 			pattern: "^https://github.com/([^/]+)/([^/]+)/pull/(\\d+)$",
 			type: 'script',
 			replacer: "",
 			script: "" +
+				"// ctx fields: https://github.com/rekby/obsidian-paste-transform/blob/master/script-context.ts\n" +
 				"const url=`https://api.github.com/repos/${ctx.match[1]}/${ctx.match[2]}/pulls/${ctx.match[3]}`\n" +
 				"const response = await fetch(url);\n" +
 				"const data = await response.json();\n" +
 				"const title = data.title;\n" +
 				"return `[${ctx.match[2]}#${ctx.match[3]}: ${title}](${ctx.foundText})`;",
 			enabled: false,
-			name: ""
+			name: "",
+			replacerWithSelection: ""
 		}
 	],
 	settingsFormatVersion: 2,
@@ -89,37 +97,24 @@ const DEFAULT_SETTINGS: PasteTransformSettingsV2 = {
 	scriptSecurityWarningAccepted: false,
 }
 
-class ScriptContext {
-	match: RegExpMatchArray;  // Full match object with groups
-	debug: boolean;  // Debug mode flag for user scripts
-	
-	constructor(match: RegExpMatchArray, debug: boolean) {
-		this.match = match;
-		this.debug = debug;
-	}
-	
-	// Getter for convenient access to the matched substring
-	get foundText(): string {
-		return this.match[0];
-	}
-}
-
 class ReplaceRule {
 	pattern: RegExp;
 	replacer: string;
 	script: string | null;
+	replacerWithSelection: string | null;
 	ruleNumber: number;
 	displayName: string;
 
-	constructor(pattern: string, replacer: string, script: string | null = null, ruleNumber: number, displayName: string) {
+	constructor(pattern: string, replacer: string, script: string | null, ruleNumber: number, displayName: string, replacerWithSelection: string = '') {
 		this.pattern = new RegExp(pattern, 'g'); // Add 'g' flag for global matching
 		this.replacer = replacer;
 		this.script = script;
+		this.replacerWithSelection = replacerWithSelection || null;
 		this.ruleNumber = ruleNumber;
 		this.displayName = displayName;
 	}
 
-	async executeScript(match: RegExpMatchArray, debugMode: boolean, app: App, ruleNumber: number): Promise<string> {
+	async executeScript(match: RegExpMatchArray, debugMode: boolean, app: App, ruleNumber: number, selectedText: string = ''): Promise<string> {
 		if (this.script) {
 			let timeoutId: NodeJS.Timeout | null = null;
 			try {
@@ -127,7 +122,7 @@ class ReplaceRule {
 				// Create an async function with context parameter
 				const AsyncFunction = Object.getPrototypeOf(async function(){}).constructor;
 				const fn = new AsyncFunction('ctx', this.script);
-				const context = new ScriptContext(match, debugMode);
+				const context = new ScriptContext(match, debugMode, selectedText);
 				
 			// Create a timeout that shows notification after configured timeout
 			let timeoutShown = false;
@@ -183,7 +178,7 @@ class ReplaceRule {
 	}
 
 	// Process all matches in the source text with a script
-	async executeScriptForAllMatches(source: string, debugMode: boolean, app: App, ruleNumber: number): Promise<string> {
+	async executeScriptForAllMatches(source: string, debugMode: boolean, app: App, ruleNumber: number, selectedText: string = ''): Promise<string> {
 		if (!this.script) {
 			return source;
 		}
@@ -203,7 +198,7 @@ class ReplaceRule {
 			const matchEnd = matchStart + match[0].length;
 			
 			// Execute script for this match
-			const replacement = await this.executeScript(match, debugMode, app, ruleNumber);
+			const replacement = await this.executeScript(match, debugMode, app, ruleNumber, selectedText);
 			
 			// Replace this match in the result
 			result = result.substring(0, matchStart) + replacement + result.substring(matchEnd);
@@ -246,8 +241,13 @@ export default class PasteTransform extends Plugin {
 			return;
 		}
 
+		const selectedText = this.app.workspace.activeEditor?.editor?.getSelection() || '';
+
 		if (this.settings.debugMode) {
 			console.log(`Original text: '${plainText}'`);
+			if (selectedText) {
+				console.log(`Selected text: '${selectedText}'`);
+			}
 		}
 
 		// Check if any rule matches (synchronously) before async operations
@@ -266,7 +266,7 @@ export default class PasteTransform extends Plugin {
 		}
 
 		// Apply all rules sequentially
-		const {changed, result} = await this.applyRules(plainText);
+		const {changed, result} = await this.applyRules(plainText, selectedText);
 		
 		// If we prevented default paste, we must insert text (either transformed or original)
 		if (preventedDefault) {
@@ -366,7 +366,7 @@ export default class PasteTransform extends Plugin {
 				}
 				try {
 					this.rules.push(
-						new ReplaceRule(rule.pattern, rule.replacer, rule.type === 'script' ? rule.script : null, ruleNumber, displayName)
+						new ReplaceRule(rule.pattern, rule.replacer, rule.type === 'script' ? rule.script : null, ruleNumber, displayName, rule.replacerWithSelection || '')
 					)
 				} catch (error) {
 					// Handle invalid regex patterns
@@ -384,7 +384,7 @@ export default class PasteTransform extends Plugin {
 	}
 
 	// Execute a specific rule on all matches in the source
-	private async executeRule(rule: ReplaceRule, source: string, ruleNumber: number): Promise<string> {
+	private async executeRule(rule: ReplaceRule, source: string, ruleNumber: number, selectedText: string = ''): Promise<string> {
 		// Reset the regex lastIndex to ensure we start from the beginning
 		rule.pattern.lastIndex = 0;
 		
@@ -408,10 +408,11 @@ export default class PasteTransform extends Plugin {
 			return source; // Return unchanged
 		}
 		// If a script is defined, execute it for all matches
-		return await rule.executeScriptForAllMatches(source, this.settings.debugMode, this.app, ruleNumber);
+		return await rule.executeScriptForAllMatches(source, this.settings.debugMode, this.app, ruleNumber, selectedText);
 	} else {
-		// Otherwise, use the default replacer for all matches
-		const result = source.replace(rule.pattern, rule.replacer);
+		// Use replacerWithSelection when there is selected text and it is configured, otherwise use regular replacer
+		const activeReplacer = (selectedText && rule.replacerWithSelection) ? rule.replacerWithSelection : rule.replacer;
+		const result = source.replace(rule.pattern, activeReplacer).split('$SEL').join(selectedText);
 		if (this.settings.debugMode) {
 			console.log(`${rule.displayName} - Matched regex: ${rule.pattern}`);
 			console.log(`${rule.displayName} - Result: '${result}'`);
@@ -420,7 +421,7 @@ export default class PasteTransform extends Plugin {
 	}
 	}
 
-	public async applyRules(source: string | null | undefined) : Promise<{changed: boolean, result: string}> {
+	public async applyRules(source: string | null | undefined, selectedText: string = '') : Promise<{changed: boolean, result: string}> {
 		if (source === undefined || source === null){
 			return {changed: false, result: ""};
 		}
@@ -433,7 +434,7 @@ export default class PasteTransform extends Plugin {
 	for (const rule of this.rules) {
 		try {
 			const beforeRule = result;
-			result = await this.executeRule(rule, result, rule.ruleNumber);
+			result = await this.executeRule(rule, result, rule.ruleNumber, selectedText);
 			
 			// Check if this rule changed the text
 			if (result !== beforeRule) {
@@ -599,11 +600,12 @@ class PasteTransformSettingsTab extends PluginSettingTab {
 		
 		// Try rules section
 		let trySource: TextAreaComponent | null = null;
+		let trySelectedText: TextAreaComponent | null = null;
 		let tryDest: TextAreaComponent | null = null;
 		
 		const handleChanges = async () => {
 			try {
-				const {result} = await this.plugin.applyRules(trySource?.getValue() || "");
+				const {result} = await this.plugin.applyRules(trySource?.getValue() || "", trySelectedText?.getValue() || "");
 				tryDest?.setValue(result);
 			} catch (e) {
 				tryDest?.setValue("ERROR:\n" + e);
@@ -622,6 +624,19 @@ class PasteTransformSettingsTab extends PluginSettingTab {
 				});
 			});
 		sourceSetting.settingEl.classList.add('test-rules-setting');
+
+		const selectedTextSetting = new Setting(testContainer)
+			.setName("Test Selected Text")
+			.setDesc("Simulate selected text in the editor (used by 'Replacer with selection' and $SEL placeholder)")
+			.addTextArea(ta => {
+				trySelectedText = ta;
+				ta.setPlaceholder("Enter simulated selected text");
+				ta.inputEl.classList.add('test-textarea');
+				ta.onChange(async () => {
+					await handleChanges();
+				});
+			});
+		selectedTextSetting.settingEl.classList.add('test-rules-setting');
 			
 		const resultSetting = new Setting(testContainer)
 			.setName("Test Result")
@@ -783,6 +798,19 @@ class PasteTransformSettingsTab extends PluginSettingTab {
 				await this.plugin.saveSettings();
 				this.plugin.compileRules();
 			});
+
+			// Replacer with selection input (shown only for replace rules)
+			const replacerWithSelectionContainer = ruleContainer.createDiv({cls: 'replacer-container'});
+			replacerWithSelectionContainer.createEl('label', {text: 'Replacer (with selection)'});
+			const replacerWithSelectionInput = new TextComponent(replacerWithSelectionContainer);
+			replacerWithSelectionInput.setValue(rule.replacerWithSelection || '');
+			replacerWithSelectionInput.setPlaceholder("Replacer to use when text is selected (optional)");
+			replacerWithSelectionInput.inputEl.classList.add('text-input-full');
+			replacerWithSelectionInput.onChange(async (value) => {
+				this.plugin.settings.rules[index].replacerWithSelection = value;
+				await this.plugin.saveSettings();
+				this.plugin.compileRules();
+			});
 		}
 			
 		// Script textarea (multi-line if type is 'script')
@@ -897,7 +925,8 @@ class PasteTransformSettingsTab extends PluginSettingTab {
 				replacer: "",
 				script: "",
 				enabled: true,
-				name: ""
+				name: "",
+				replacerWithSelection: ""
 			});
 			await this.plugin.saveSettings();
 			this.plugin.compileRules();

--- a/main.ts
+++ b/main.ts
@@ -18,6 +18,7 @@ interface Rule {
 	replacer: string; // Used when type is 'replace'
 	script: string;   // Used when type is 'script'
 	enabled: boolean; // Whether the rule is enabled
+	name: string;     // Optional name for the rule
 }
 
 
@@ -44,14 +45,16 @@ const DEFAULT_SETTINGS: PasteTransformSettingsV2 = {
 			type: 'replace',
 			replacer: "[🐈‍⬛ $1]($&)",
 			script: "",
-			enabled: true
+			enabled: true,
+			name: ""
 		},
 		{
 			pattern: "^https://\\w+.wikipedia.org/wiki/([^\\s]+)$",
 			type: 'replace',
 			replacer: "[📖 $1]($&)",
 			script: "",
-			enabled: true
+			enabled: true,
+			name: ""
 		},
 		{
 			pattern: "^https://github.com/([^/]+)/([^/]+)/issues/(\\d+)$",
@@ -63,7 +66,8 @@ const DEFAULT_SETTINGS: PasteTransformSettingsV2 = {
 				"const data = await response.json();\n" +
 				"const title = data.title;\n" +
 				"return `[${ctx.match[2]}#${ctx.match[3]}: ${title}](${ctx.foundText})`;",
-			enabled: false
+			enabled: false,
+			name: ""
 		},
 		{
 			pattern: "^https://github.com/([^/]+)/([^/]+)/pull/(\\d+)$",
@@ -75,7 +79,8 @@ const DEFAULT_SETTINGS: PasteTransformSettingsV2 = {
 				"const data = await response.json();\n" +
 				"const title = data.title;\n" +
 				"return `[${ctx.match[2]}#${ctx.match[3]}: ${title}](${ctx.foundText})`;",
-			enabled: false
+			enabled: false,
+			name: ""
 		}
 	],
 	settingsFormatVersion: 2,
@@ -104,12 +109,14 @@ class ReplaceRule {
 	replacer: string;
 	script: string | null;
 	ruleNumber: number;
+	displayName: string;
 
-	constructor(pattern: string, replacer: string, script: string | null = null, ruleNumber: number) {
+	constructor(pattern: string, replacer: string, script: string | null = null, ruleNumber: number, displayName: string) {
 		this.pattern = new RegExp(pattern, 'g'); // Add 'g' flag for global matching
 		this.replacer = replacer;
 		this.script = script;
 		this.ruleNumber = ruleNumber;
+		this.displayName = displayName;
 	}
 
 	async executeScript(match: RegExpMatchArray, debugMode: boolean, app: App, ruleNumber: number): Promise<string> {
@@ -122,14 +129,14 @@ class ReplaceRule {
 				const fn = new AsyncFunction('ctx', this.script);
 				const context = new ScriptContext(match, debugMode);
 				
-				// Create a timeout that shows notification after configured timeout
-				let timeoutShown = false;
-				timeoutId = setTimeout(() => {
-					if (!timeoutShown) {
-						timeoutShown = true;
-						new Notice(`Rule #${ruleNumber} is taking longer than expected`, NOTICE_DURATION_NORMAL);
-					}
-				}, SCRIPT_TIMEOUT_MS);
+			// Create a timeout that shows notification after configured timeout
+			let timeoutShown = false;
+			timeoutId = setTimeout(() => {
+				if (!timeoutShown) {
+					timeoutShown = true;
+					new Notice(`${this.displayName} is taking longer than expected`, NOTICE_DURATION_NORMAL);
+				}
+			}, SCRIPT_TIMEOUT_MS);
 				
 				// Execute the script
 				const scriptPromise = fn(context);
@@ -151,20 +158,20 @@ class ReplaceRule {
 					console.log(`Result: '${result}'`);
 				}
 				return result;
-			} catch (error) {
-			// Clear the timeout since script completed (with error)
-			if (timeoutId !== null) {
-				clearTimeout(timeoutId);
-				timeoutId = null;
-			}
-			
-			console.error(`Error executing script for rule #${ruleNumber}:`, error);
-			// Show error notification in Obsidian
-			const errorMessage = error instanceof Error ? error.message : String(error);
-			new Notice(`Rule #${ruleNumber} script execution error: ${errorMessage}`, NOTICE_DURATION_NORMAL);
-			// Return the original match if there's an error
-			return match[0];
-			}
+		} catch (error) {
+		// Clear the timeout since script completed (with error)
+		if (timeoutId !== null) {
+			clearTimeout(timeoutId);
+			timeoutId = null;
+		}
+		
+		console.error(`Error executing script for ${this.displayName}:`, error);
+		// Show error notification in Obsidian
+		const errorMessage = error instanceof Error ? error.message : String(error);
+		new Notice(`${this.displayName} script execution error: ${errorMessage}`, NOTICE_DURATION_NORMAL);
+		// Return the original match if there's an error
+		return match[0];
+		}
 		}
 		// If no script, use the default replacer
 		const result = match[0].replace(this.pattern, this.replacer);
@@ -297,15 +304,16 @@ export default class PasteTransform extends Plugin {
 		const newRules: Rule[] = [];
 		const minIndex = Math.min(oldSettings.patterns.length, oldSettings.replacers.length);
 		
-		for (let i = 0; i < minIndex; i++) {
-			newRules.push({
-				pattern: oldSettings.patterns[i],
-				type: 'replace',
-				replacer: oldSettings.replacers[i],
-				script: '',
-				enabled: true
-			});
-		}
+	for (let i = 0; i < minIndex; i++) {
+		newRules.push({
+			pattern: oldSettings.patterns[i],
+			type: 'replace',
+			replacer: oldSettings.replacers[i],
+			script: '',
+			enabled: true,
+			name: ''
+		});
+	}
 			
 			// Create new settings object with converted data
 			this.settings = {
@@ -319,13 +327,20 @@ export default class PasteTransform extends Plugin {
 			// Use default settings merged with loaded data (new format)
 			this.settings = Object.assign({}, DEFAULT_SETTINGS, loadedData);
 			
-			// Ensure scriptSecurityWarningAccepted is set (for backward compatibility with v2 without this field)
-			if (this.settings.scriptSecurityWarningAccepted === undefined) {
-				this.settings.scriptSecurityWarningAccepted = false;
-			}
+		// Ensure scriptSecurityWarningAccepted is set (for backward compatibility with v2 without this field)
+		if (this.settings.scriptSecurityWarningAccepted === undefined) {
+			this.settings.scriptSecurityWarningAccepted = false;
 		}
-		
-		// Auto-disable script security flag if there are no enabled script rules
+	}
+	
+	// Normalize rules: ensure name field exists (for backward compatibility)
+	this.settings.rules.forEach(rule => {
+		if (rule.name === undefined) {
+			rule.name = '';
+		}
+	});
+	
+	// Auto-disable script security flag if there are no enabled script rules
 		const hasEnabledScriptRules = this.settings.rules.some(rule => 
 			rule.type === 'script' && rule.enabled
 		);
@@ -342,6 +357,7 @@ export default class PasteTransform extends Plugin {
 		for (let i = 0; i < this.settings.rules.length; i++) {
 			const rule = this.settings.rules[i];
 			const ruleNumber = i + 1; // Rule numbers start from 1 for users (based on position in settings)
+			const displayName = rule.name || `Rule #${ruleNumber}`;
 			
 			if (rule.enabled) {
 				// Skip script rules if security warning not accepted
@@ -350,13 +366,13 @@ export default class PasteTransform extends Plugin {
 				}
 				try {
 					this.rules.push(
-						new ReplaceRule(rule.pattern, rule.replacer, rule.type === 'script' ? rule.script : null, ruleNumber)
+						new ReplaceRule(rule.pattern, rule.replacer, rule.type === 'script' ? rule.script : null, ruleNumber, displayName)
 					)
 				} catch (error) {
 					// Handle invalid regex patterns
-					console.error(`Error compiling rule #${ruleNumber}:`, error);
+					console.error(`Error compiling ${displayName}:`, error);
 					const errorMessage = error instanceof Error ? error.message : String(error);
-					new Notice(`Rule #${ruleNumber} has invalid pattern: ${errorMessage}`, NOTICE_DURATION_NORMAL);
+					new Notice(`${displayName} has invalid pattern: ${errorMessage}`, NOTICE_DURATION_NORMAL);
 					// Skip this rule and continue with others
 				}
 			}
@@ -380,28 +396,28 @@ export default class PasteTransform extends Plugin {
 			return source;
 		}
 
-		if (this.settings.debugMode) {
-			console.log(`Rule #${ruleNumber} triggered`);
-		}
+	if (this.settings.debugMode) {
+		console.log(`${rule.displayName} triggered`);
+	}
 
-		if (rule.script) {
-			// This should never happen (script rules are filtered in compileRules), but check just in case
-			if (!this.settings.scriptSecurityWarningAccepted) {
-				console.error('BUG: Script rule executed without security acceptance. Please report this to the plugin developers.');
-				new Notice('⚠️ Security error detected. Script execution blocked. Please report this bug to the plugin developers.', NOTICE_DURATION_LONG);
-				return source; // Return unchanged
-			}
-			// If a script is defined, execute it for all matches
-			return await rule.executeScriptForAllMatches(source, this.settings.debugMode, this.app, ruleNumber);
-		} else {
-			// Otherwise, use the default replacer for all matches
-			const result = source.replace(rule.pattern, rule.replacer);
-			if (this.settings.debugMode) {
-				console.log(`Rule #${ruleNumber} - Matched regex: ${rule.pattern}`);
-				console.log(`Rule #${ruleNumber} - Result: '${result}'`);
-			}
-			return result;
+	if (rule.script) {
+		// This should never happen (script rules are filtered in compileRules), but check just in case
+		if (!this.settings.scriptSecurityWarningAccepted) {
+			console.error('BUG: Script rule executed without security acceptance. Please report this to the plugin developers.');
+			new Notice('⚠️ Security error detected. Script execution blocked. Please report this bug to the plugin developers.', NOTICE_DURATION_LONG);
+			return source; // Return unchanged
 		}
+		// If a script is defined, execute it for all matches
+		return await rule.executeScriptForAllMatches(source, this.settings.debugMode, this.app, ruleNumber);
+	} else {
+		// Otherwise, use the default replacer for all matches
+		const result = source.replace(rule.pattern, rule.replacer);
+		if (this.settings.debugMode) {
+			console.log(`${rule.displayName} - Matched regex: ${rule.pattern}`);
+			console.log(`${rule.displayName} - Result: '${result}'`);
+		}
+		return result;
+	}
 	}
 
 	public async applyRules(source: string | null | undefined) : Promise<{changed: boolean, result: string}> {
@@ -409,45 +425,45 @@ export default class PasteTransform extends Plugin {
 			return {changed: false, result: ""};
 		}
 
-		let result = source;
-		let changed = false;
-		const triggeredRuleNumbers: number[] = [];
+	let result = source;
+	let changed = false;
+	const triggeredRuleNames: string[] = [];
 
-		// Apply all rules sequentially
-		for (const rule of this.rules) {
-			try {
-				const beforeRule = result;
-				result = await this.executeRule(rule, result, rule.ruleNumber);
-				
-				// Check if this rule changed the text
-				if (result !== beforeRule) {
-					changed = true;
-					triggeredRuleNumbers.push(rule.ruleNumber);
-				}
-			} catch (error) {
-				// Show error notification in Obsidian
-				console.error(`Error applying rule #${rule.ruleNumber}:`, error);
-				const errorMessage = error instanceof Error ? error.message : String(error);
-				new Notice(`Rule #${rule.ruleNumber} execution error: ${errorMessage}`, NOTICE_DURATION_NORMAL);
-				// Continue with the next rule, keeping the text unchanged
+	// Apply all rules sequentially
+	for (const rule of this.rules) {
+		try {
+			const beforeRule = result;
+			result = await this.executeRule(rule, result, rule.ruleNumber);
+			
+			// Check if this rule changed the text
+			if (result !== beforeRule) {
+				changed = true;
+				triggeredRuleNames.push(rule.displayName);
 			}
+		} catch (error) {
+			// Show error notification in Obsidian
+			console.error(`Error applying ${rule.displayName}:`, error);
+			const errorMessage = error instanceof Error ? error.message : String(error);
+			new Notice(`${rule.displayName} execution error: ${errorMessage}`, NOTICE_DURATION_NORMAL);
+			// Continue with the next rule, keeping the text unchanged
 		}
-
-	// Show notification with all triggered rules if enabled
-	if (changed && this.settings.showRuleNotifications && triggeredRuleNumbers.length > 0) {
-		const rulesList = triggeredRuleNumbers.join(', ');
-		const message = triggeredRuleNumbers.length === 1 
-			? `Rule #${rulesList} triggered`
-			: `Rules #${rulesList} triggered`;
-		new Notice(message, NOTICE_DURATION_SHORT);
 	}
 
-		// Log all triggered rules
-		if (this.settings.debugMode && triggeredRuleNumbers.length > 0) {
-			console.log(`Triggered rules: #${triggeredRuleNumbers.join(', #')}`);
-		}
+// Show notification with all triggered rules if enabled
+if (changed && this.settings.showRuleNotifications && triggeredRuleNames.length > 0) {
+	const rulesList = triggeredRuleNames.join(', ');
+	const message = triggeredRuleNames.length === 1 
+		? `${rulesList} triggered`
+		: `${rulesList} triggered`;
+	new Notice(message, NOTICE_DURATION_SHORT);
+}
 
-		return {changed, result};
+	// Log all triggered rules
+	if (this.settings.debugMode && triggeredRuleNames.length > 0) {
+		console.log(`Triggered rules: ${triggeredRuleNames.join(', ')}`);
+	}
+
+	return {changed, result};
 	}
 }
 
@@ -639,9 +655,17 @@ class PasteTransformSettingsTab extends PluginSettingTab {
 			const dragHandle = headerRow.createDiv({cls: 'drag-handle'});
 			setIcon(dragHandle, 'grip-vertical');
 			
-		// Rule number
+		// Rule number / name input
 		const ruleNumber = index + 1;
-		const ruleNumberEl = headerRow.createEl('span', {text: `Rule #${ruleNumber}`, cls: 'rule-number'});
+		const nameInputContainer = headerRow.createDiv({cls: 'rule-name-container'});
+		const nameInput = new TextComponent(nameInputContainer);
+		nameInput.setPlaceholder(`Rule #${ruleNumber}`);
+		nameInput.setValue(rule.name);
+		nameInput.onChange(async (value) => {
+			this.plugin.settings.rules[index].name = value;
+			await this.plugin.saveSettings();
+			this.plugin.compileRules();
+		});
 			
 			// Type toggle
 			const typeDropdownContainer = headerRow.createDiv({cls: 'type-dropdown-container'});
@@ -872,7 +896,8 @@ class PasteTransformSettingsTab extends PluginSettingTab {
 				type: 'replace',
 				replacer: "",
 				script: "",
-				enabled: true
+				enabled: true,
+				name: ""
 			});
 			await this.plugin.saveSettings();
 			this.plugin.compileRules();

--- a/script-context.ts
+++ b/script-context.ts
@@ -1,0 +1,31 @@
+/**
+ * Context object passed to script rules as `ctx`.
+ *
+ * Every script rule receives a single `ctx` argument of this type.
+ * Use it to access the matched text, capture groups, selected editor text,
+ * and the debug flag.
+ *
+ * See README for usage examples:
+ * https://github.com/rekby/obsidian-paste-transform#javascript-execution-rules
+ */
+export class ScriptContext {
+	/** Full match object with capture groups (result of `string.match(regexp)`). */
+	match: RegExpMatchArray;
+
+	/** `true` when debug mode is enabled in plugin settings. Useful for conditional logging. */
+	debug: boolean;
+
+	/** Text currently selected in the editor at the time of paste. Empty string if nothing is selected. */
+	selectedText: string;
+
+	constructor(match: RegExpMatchArray, debug: boolean, selectedText: string) {
+		this.match = match;
+		this.debug = debug;
+		this.selectedText = selectedText;
+	}
+
+	/** The matched substring — a shorthand for `ctx.match[0]`. */
+	get foundText(): string {
+		return this.match[0];
+	}
+}


### PR DESCRIPTION
## Summary
- add a global `Paste Transform Enabled` setting and three commands (enable/disable/toggle) to control paste transformation without editing rules
- extend rule behavior with optional rule names, `Replacer (with selection)`, `$SEL` placeholder support, and `ctx.selectedText` in script context
- improve settings UX and feedback messages, add `script-context.ts`, and expand tests plus README/agent docs to cover new behavior and backward compatibility

## Test plan
- [x] `npm run build`
- [x] `npm test`
- [x] verify migration/backward-compatibility tests for older settings formats

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core paste-handling flow and rule application logic (including settings migration), which could affect whether/when pastes are intercepted and transformed. Risk is mitigated by expanded unit tests covering toggle state, selection behavior, and backward compatibility.
> 
> **Overview**
> Adds a **global enable/disable switch** for paste transformation (`pasteTransformEnabled`), surfaced in settings and via new commands (`enable`, `disable`, `toggle`), and short-circuits `onPaste` when disabled.
> 
> Extends rules with **optional names** and a **selection-aware replacer** (`replacerWithSelection`), plus `$SEL` placeholder support and `ctx.selectedText` for script rules; notifications/logging now use the rule display name instead of just rule numbers.
> 
> Extracts `ScriptContext` to new `script-context.ts`, updates default rules to leverage selection titles, improves settings UX (rule name input, safer drag handle behavior, selected-text test box), and expands Jest coverage + docs (README + agent docs) including migration defaults for the new setting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0862d8b362967374d24c0529a893eca821714344. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->