### PR TITLE
fix: accept paste when text/plain is present alongside other clipboard types

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -275,7 +275,7 @@ export default class PasteTransform extends Plugin {
 		if (this.settings.debugMode) {
 			console.log("transform plugin, clipboard content types:", types);
 		}
-		if (types === undefined || types.length != 1 || types[0] != "text/plain"){
+		if (types === undefined || !types.includes("text/plain")){
 			return;
 		}
 		let plainText = event.clipboardData?.getData("text/plain");


### PR DESCRIPTION
## Problem

When copying text within Obsidian, the clipboard contains multiple types: `text/plain` and `text/html` (Obsidian wraps copied text in `<a>` tags). The current check on line 278:

```ts
if (types === undefined || types.length != 1 || types[0] != "text/plain")
```

rejects these pastes because `types.length != 1`. This means the plugin only works for external pastes (e.g., from a browser address bar) but not for text copied within Obsidian itself.

## Fix

Changed the check to verify `text/plain` is **included** in clipboard types, regardless of other types present:

```ts
if (types === undefined || !types.includes("text/plain"))
```

The plugin still reads only `text/plain` data via `getData("text/plain")`, so the HTML content is safely ignored.

## Testing

- ✅ Paste from browser address bar → rules trigger (as before)
- ✅ Copy URL text within Obsidian → paste into another note → rules now trigger
- ✅ Rich paste (images, files) unaffected — no `text/plain` type present